### PR TITLE
refresh logout

### DIFF
--- a/src/main/java/com/minsta/m/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/minsta/m/domain/auth/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.minsta.m.domain.auth.controller;
+
+import com.minsta.m.domain.auth.service.LogoutService;
+import com.minsta.m.domain.auth.service.ReIssueTokenService;
+import com.minsta.m.domain.user.controller.data.response.LoginResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final ReIssueTokenService reIssueTokenService;
+    private final LogoutService logoutService;
+
+    @PatchMapping
+    public ResponseEntity<LoginResponse> reIssueToken(HttpServletRequest request, HttpServletResponse response) {
+        var res = reIssueTokenService.execute(request.getCookies(), response);
+        return new ResponseEntity<>(res, HttpStatus.OK);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<HttpStatus> logout(HttpServletRequest request) {
+        logoutService.execute(request);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/auth/entity/BlackList.java
+++ b/src/main/java/com/minsta/m/domain/auth/entity/BlackList.java
@@ -1,0 +1,30 @@
+package com.minsta.m.domain.auth.entity;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Builder
+@RedisHash(value = "BlackList")
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlackList {
+
+    @Id
+    private Long userId;
+
+    @Indexed
+    private String accessToken;
+
+    @Indexed
+    private String refreshToken;
+
+    @TimeToLive
+    private long expiredIn;
+}

--- a/src/main/java/com/minsta/m/domain/auth/repository/BlackListRepository.java
+++ b/src/main/java/com/minsta/m/domain/auth/repository/BlackListRepository.java
@@ -1,0 +1,11 @@
+package com.minsta.m.domain.auth.repository;
+
+import com.minsta.m.domain.auth.entity.BlackList;
+import org.springframework.data.repository.CrudRepository;
+
+public interface BlackListRepository extends CrudRepository<BlackList, Long> {
+
+    boolean existsByAccessToken(String accessToken);
+
+    boolean existsByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/minsta/m/domain/auth/service/LogoutService.java
+++ b/src/main/java/com/minsta/m/domain/auth/service/LogoutService.java
@@ -1,0 +1,9 @@
+package com.minsta.m.domain.auth.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface LogoutService {
+
+    void execute(HttpServletRequest request);
+}

--- a/src/main/java/com/minsta/m/domain/auth/service/ReIssueTokenService.java
+++ b/src/main/java/com/minsta/m/domain/auth/service/ReIssueTokenService.java
@@ -1,0 +1,10 @@
+package com.minsta.m.domain.auth.service;
+
+import com.minsta.m.domain.user.controller.data.response.LoginResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface ReIssueTokenService {
+
+    LoginResponse execute(Cookie[] cookies, HttpServletResponse response);
+}

--- a/src/main/java/com/minsta/m/domain/auth/service/impl/LogoutServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/auth/service/impl/LogoutServiceImpl.java
@@ -1,0 +1,47 @@
+package com.minsta.m.domain.auth.service.impl;
+
+import com.minsta.m.domain.auth.entity.BlackList;
+import com.minsta.m.domain.auth.repository.BlackListRepository;
+import com.minsta.m.domain.auth.service.LogoutService;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.security.exception.TokenExpiredException;
+import com.minsta.m.global.security.exception.TokenNotValidException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@ServiceWithTransactional
+@RequiredArgsConstructor
+public class LogoutServiceImpl implements LogoutService {
+
+    private final BlackListRepository blackListRepository;
+
+    @Override
+    public void execute(HttpServletRequest request) {
+        String token = null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("refreshToken".equals(cookie.getName())) {
+                token = cookie.getValue();
+                break;
+            }
+        }
+
+        if (token == null) {
+            throw new TokenNotValidException();
+        }
+
+        if (blackListRepository.existsByRefreshToken(token)) {
+            throw new TokenExpiredException();
+        }
+
+        BlackList blackList = BlackList
+                .builder()
+                .accessToken(request.getHeader("Authorization"))
+                .refreshToken(token)
+                .expiredIn(1209600)
+                .build();
+
+        blackListRepository.save(blackList);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/auth/service/impl/ReIssueTokenServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/auth/service/impl/ReIssueTokenServiceImpl.java
@@ -1,0 +1,54 @@
+package com.minsta.m.domain.auth.service.impl;
+
+import com.minsta.m.common.cookie.CookieManager;
+import com.minsta.m.domain.auth.repository.BlackListRepository;
+import com.minsta.m.domain.auth.service.ReIssueTokenService;
+import com.minsta.m.domain.user.controller.data.response.LoginResponse;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.security.exception.TokenExpiredException;
+import com.minsta.m.global.security.exception.TokenNotValidException;
+import com.minsta.m.global.security.jwt.TokenIssuer;
+import com.minsta.m.global.security.jwt.TokenParser;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@ServiceWithTransactional
+@RequiredArgsConstructor
+public class ReIssueTokenServiceImpl implements ReIssueTokenService {
+
+    private final TokenIssuer tokenIssuer;
+    private final TokenParser tokenParser;
+    private final BlackListRepository blackListRepository;
+    private final CookieManager cookieManager;
+
+    @Override
+    public LoginResponse execute(Cookie[] cookies, HttpServletResponse response) {
+        String token = null;
+
+        for (Cookie cookie : cookies) {
+            if ("refreshToken".equals(cookie.getName())) {
+                token = cookie.getValue();
+                break;
+            }
+        }
+
+        if (token == null) {
+            throw new TokenNotValidException();
+        }
+
+        if (blackListRepository.existsByRefreshToken(token)) {
+            throw new TokenExpiredException();
+        }
+
+        String phone = tokenParser.extractEmailWithClaim(token);
+        cookieManager.addCookie(tokenIssuer.generateRefreshToken(phone), response);
+
+        return LoginResponse.builder()
+                .accessToken(tokenIssuer.generateAccessToken(phone))
+                .expiredAt(ZonedDateTime.now().plusSeconds(tokenIssuer.getExpiredTime()))
+                .build();
+    }
+}

--- a/src/main/java/com/minsta/m/global/filter/JwtFilter.java
+++ b/src/main/java/com/minsta/m/global/filter/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.minsta.m.global.filter;
 
+import com.minsta.m.domain.auth.repository.BlackListRepository;
 import com.minsta.m.global.security.exception.TokenExpiredException;
 import com.minsta.m.global.security.jwt.TokenParser;
 import jakarta.servlet.FilterChain;
@@ -20,6 +21,7 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final TokenParser tokenParser;
+    private final BlackListRepository blackListRepository;
 
     @Override
     protected void doFilterInternal(
@@ -30,6 +32,10 @@ public class JwtFilter extends OncePerRequestFilter {
         String token = tokenParser.resolveToken(request);
 
         if (token != null && !token.isBlank()) {
+            if (blackListRepository.existsByAccessToken(token)) {
+                throw new TokenExpiredException();
+            }
+
             Authentication authentication = tokenParser.authentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
                 .and()
                 .authorizeHttpRequests()
                 .requestMatchers(HttpMethod.POST, "/user/**").permitAll()
+                .requestMatchers(HttpMethod.PATCH, "/auth").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
                 .anyRequest().denyAll();
 
         http


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 인증 관련 작업을 처리하는 `AuthController`를 추가했습니다. 토큰 재발급 및 사용자 로그아웃 엔드포인트를 포함합니다.
	- 사용자 토큰을 블랙리스트에 관리하는 `BlackList` 엔티티 클래스를 추가했습니다. Redis 캐시 통합을 위한 주석이 포함된 사용자 ID, 액세스 토큰, 리프레시 토큰, 만료 시간 필드를 포함합니다.
	- 액세스 토큰과 리프레시 토큰의 블랙리스트를 관리하는 인터페이스 `BlackListRepository`를 추가했습니다.
	- 사용자 로그아웃 기능을 처리하는 `LogoutService` 인터페이스를 추가했습니다. `HttpServletRequest`를 매개변수로 취하는 메소드를 실행합니다.
	- 사용자 인증 시 토큰을 재발급하는 `ReIssueTokenService` 인터페이스를 추가했습니다. 쿠키와 HTTP 응답을 처리합니다.
	- 사용자를 로그아웃시키는 `LogoutServiceImpl`을 구현했습니다. 리프레시 토큰을 무효화하고 더 이상 사용하지 못하도록 블랙리스트에 저장합니다.
	- 사용자 인증을 위한 토큰을 재발급하는 `ReIssueTokenServiceImpl`을 구현했습니다. 토큰의 유효성을 검증하고 새로운 토큰을 생성합니다.
	- `JwtFilter`에 `BlackListRepository`를 가져오는 새로운 import 문을 추가하고, 블랙리스트 저장소에서 토큰 존재 여부를 확인하는 기능을 구현했습니다.
	- `SecurityConfig`에서 "/auth"에 대한 PATCH 및 DELETE 요청에 인증 요구 사항을 도입하여 특정 HTTP 메소드에 대한 인증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->