### PR TITLE
create leels comment

### DIFF
--- a/src/main/java/com/minsta/m/domain/leels/controller/LeelsCommentController.java
+++ b/src/main/java/com/minsta/m/domain/leels/controller/LeelsCommentController.java
@@ -1,0 +1,26 @@
+package com.minsta.m.domain.leels.controller;
+
+import com.minsta.m.domain.leels.controller.data.request.CreateLeelsCommentRequest;
+import com.minsta.m.domain.leels.service.CreateLeelsCommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/leels/{leelsId}")
+@RequiredArgsConstructor
+public class LeelsCommentController {
+
+    private final CreateLeelsCommentService createLeelsCommentService;
+
+    @PostMapping
+    public ResponseEntity<HttpStatus> createLeelsComment(
+            @RequestBody @Valid CreateLeelsCommentRequest createLeelsCommentRequest,
+            @PathVariable Long leelsId
+    ) {
+        createLeelsCommentService.execute(createLeelsCommentRequest, leelsId);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/leels/controller/data/request/CreateLeelsCommentRequest.java
+++ b/src/main/java/com/minsta/m/domain/leels/controller/data/request/CreateLeelsCommentRequest.java
@@ -1,0 +1,15 @@
+package com.minsta.m.domain.leels.controller.data.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateLeelsCommentRequest {
+
+    @NotNull(message = "comment is necessary value")
+    private String comment;
+}

--- a/src/main/java/com/minsta/m/domain/leels/entity/LeelsComment.java
+++ b/src/main/java/com/minsta/m/domain/leels/entity/LeelsComment.java
@@ -1,0 +1,33 @@
+package com.minsta.m.domain.leels.entity;
+
+import com.minsta.m.domain.user.entity.User;
+import com.minsta.m.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeelsComment extends BaseEntity {
+
+    @Id
+    @Column(name = "leels_comment_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long leelsCommentId;
+
+    @ManyToOne
+    @JoinColumn(name = "leels_id")
+    private Leels leels;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false, length = 100)
+    private String comment;
+}

--- a/src/main/java/com/minsta/m/domain/leels/exception/LeelsNotFoundException.java
+++ b/src/main/java/com/minsta/m/domain/leels/exception/LeelsNotFoundException.java
@@ -1,0 +1,11 @@
+package com.minsta.m.domain.leels.exception;
+
+import com.minsta.m.global.error.BasicException;
+import com.minsta.m.global.error.ErrorCode;
+
+public class LeelsNotFoundException extends BasicException {
+
+    public LeelsNotFoundException() {
+        super(ErrorCode.LEELS_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/leels/repository/LeelsCommentRepository.java
+++ b/src/main/java/com/minsta/m/domain/leels/repository/LeelsCommentRepository.java
@@ -1,0 +1,7 @@
+package com.minsta.m.domain.leels.repository;
+
+import com.minsta.m.domain.leels.entity.LeelsComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LeelsCommentRepository extends JpaRepository<LeelsComment, Long> {
+}

--- a/src/main/java/com/minsta/m/domain/leels/service/CreateLeelsCommentService.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/CreateLeelsCommentService.java
@@ -1,0 +1,8 @@
+package com.minsta.m.domain.leels.service;
+
+import com.minsta.m.domain.leels.controller.data.request.CreateLeelsCommentRequest;
+
+public interface CreateLeelsCommentService {
+
+    void execute(CreateLeelsCommentRequest createLeelsCommentRequest, Long leelsId);
+}

--- a/src/main/java/com/minsta/m/domain/leels/service/impl/CreateLeelsCommentServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/impl/CreateLeelsCommentServiceImpl.java
@@ -1,0 +1,31 @@
+package com.minsta.m.domain.leels.service.impl;
+
+import com.minsta.m.domain.leels.entity.LeelsComment;
+import com.minsta.m.domain.leels.controller.data.request.CreateLeelsCommentRequest;
+import com.minsta.m.domain.leels.repository.LeelsCommentRepository;
+import com.minsta.m.domain.leels.service.CreateLeelsCommentService;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.util.LeelsUtil;
+import com.minsta.m.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@ServiceWithTransactional
+public class CreateLeelsCommentServiceImpl implements CreateLeelsCommentService {
+
+    private final LeelsCommentRepository leelsCommentRepository;
+    private final UserUtil userUtil;
+    private final LeelsUtil leelsUtil;
+
+    @Override
+    public void execute(CreateLeelsCommentRequest createLeelsCommentRequest, Long leelsId) {
+
+        LeelsComment leelsComment = LeelsComment.builder()
+                .leels(leelsUtil.getLeels(leelsId))
+                .user(userUtil.getUser())
+                .comment(createLeelsCommentRequest.getComment())
+                .build();
+
+        leelsCommentRepository.save(leelsComment);
+    }
+}

--- a/src/main/java/com/minsta/m/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/minsta/m/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.minsta.m.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/minsta/m/global/error/ErrorCode.java
+++ b/src/main/java/com/minsta/m/global/error/ErrorCode.java
@@ -25,7 +25,10 @@ public enum ErrorCode {
     //AWS
     FILE_UPLOAD_FAIL("파일 업로드에 실패했습니다.", 500),
     NOT_ALLOWED_FILE("허용되지 않은 파일 형식입니다.", 400),
-    INVALID_FORMAT_FILE("잘못된 형식의 파일입니다.", 400);
+    INVALID_FORMAT_FILE("잘못된 형식의 파일입니다.", 400),
+
+    //Leels
+    LEELS_NOT_FOUND("릴스가 없습니다", 404);
 
 
     private final String message;

--- a/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/user/**").permitAll()
                 .requestMatchers(HttpMethod.PATCH, "/auth").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
-                .requestMatchers(HttpMethod.POST, "/leels").authenticated()
+                .requestMatchers(HttpMethod.POST, "/leels/**").authenticated()
                 .requestMatchers(HttpMethod.POST, "/file").authenticated()
                 .anyRequest().denyAll();
 

--- a/src/main/java/com/minsta/m/global/util/LeelsUtil.java
+++ b/src/main/java/com/minsta/m/global/util/LeelsUtil.java
@@ -1,0 +1,18 @@
+package com.minsta.m.global.util;
+
+import com.minsta.m.domain.leels.entity.Leels;
+import com.minsta.m.domain.leels.exception.LeelsNotFoundException;
+import com.minsta.m.domain.leels.repository.LeelsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LeelsUtil {
+
+    private final LeelsRepository leelsRepository;
+
+    public Leels getLeels(Long leelsId) {
+        return leelsRepository.findById(leelsId).orElseThrow(LeelsNotFoundException::new);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 특정 "leels" 엔티티에 대한 댓글 생성을 처리하는 새로운 컨트롤러가 추가되었습니다.
	- "leels" 도메인에서 댓글을 생성하기 위한 데이터 요청 클래스가 정의되었습니다.
	- "Leels" 엔티티에 대한 댓글을 위한 엔티티 클래스가 정의되었습니다.
	- "leels" 엔티티가 없을 경우를 위한 새로운 예외 클래스가 추가되었습니다.
	- JPA 감사를 활성화하는 새로운 스프링 구성 클래스가 추가되었습니다.
	- "/leels"에 대한 POST 요청에 인증을 요구하는 보안 설정이 업데이트되었습니다.
	- "Leels" 엔티티를 ID로 검색하는 유틸리티 클래스가 추가되었습니다.

- **버그 수정**
	- 없음

- **문서**
	- 없음

- **리팩토링**
	- 없음

- **스타일**
	- 없음

- **테스트**
	- 없음

- **기타 작업**
	- "Leels" 엔티티에 대한 댓글을 생성하는 서비스 인터페이스 및 구현체가 추가되었습니다.
	- "릴스가 없습니다"에 대한 새로운 오류 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->