### PR TITLE
xk comment one touch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,13 +12,14 @@ build/
 .project
 .settings
 .springBeans
-.sts4-cache
+.sts4-caches
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
 .idea
+/.idea
 *.iws
 *.iml
 *.ipr
@@ -35,3 +36,148 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Created by https://www.toptal.com/developers/gitignore/api/intellij,java
+# Edit at https://www.toptal.com/developers/gitignore?templates=intellij,java
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+# End of https://www.toptal.com/developers/gitignore/api/intellij,java
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.5'
@@ -71,6 +77,12 @@ dependencies {
 
     //AWS
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.13'
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
@@ -126,4 +138,22 @@ jacocoTestCoverageVerification {
             }
         }
     }
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/src/main/java/com/minsta/m/domain/leels/controller/LeelsCommentController.java
+++ b/src/main/java/com/minsta/m/domain/leels/controller/LeelsCommentController.java
@@ -1,8 +1,7 @@
 package com.minsta.m.domain.leels.controller;
 
 import com.minsta.m.domain.leels.controller.data.request.CreateLeelsCommentRequest;
-import com.minsta.m.domain.leels.service.CreateLeelsCommentLikeService;
-import com.minsta.m.domain.leels.service.CreateLeelsCommentService;
+import com.minsta.m.domain.leels.service.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +14,10 @@ import org.springframework.web.bind.annotation.*;
 public class LeelsCommentController {
 
     private final CreateLeelsCommentService createLeelsCommentService;
+    private final LeelsCommentDeleteService leelsCommentDeleteService;
     private final CreateLeelsCommentLikeService createLeelsCommentLikeService;
+    private final UpdateLeelsCommentService updateLeelsCommentService;
+    private final LeelsCommentLikeCancelService leelsCommentLikeCancelService;
 
     @PostMapping
     public ResponseEntity<HttpStatus> createLeelsComment(
@@ -33,5 +35,33 @@ public class LeelsCommentController {
     ) {
         createLeelsCommentLikeService.execute(leelsId, leelsCommentId);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/{leelsCommentId}")
+    public ResponseEntity<HttpStatus> deleteLeelsComment(
+            @PathVariable Long leelsId,
+            @PathVariable Long leelsCommentId
+    ) {
+        leelsCommentDeleteService.execute(leelsId, leelsCommentId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PatchMapping("/{leelsCommentId}")
+    public ResponseEntity<HttpStatus> updateComment(
+            @PathVariable Long leelsId,
+            @PathVariable Long leelsCommentId,
+            @RequestBody @Valid CreateLeelsCommentRequest updateCommentRequest
+    ) {
+        updateLeelsCommentService.execute(leelsId, leelsCommentId, updateCommentRequest);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PutMapping("/{leelsCommentId}")
+    public ResponseEntity<HttpStatus> leelsCommentLikeCancel(
+            @PathVariable Long leelsId,
+            @PathVariable Long leelsCommentId
+    ) {
+        leelsCommentLikeCancelService.execute(leelsId, leelsCommentId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/minsta/m/domain/leels/entity/LeelsComment.java
+++ b/src/main/java/com/minsta/m/domain/leels/entity/LeelsComment.java
@@ -30,4 +30,8 @@ public class LeelsComment extends BaseEntity {
 
     @Column(nullable = false, length = 100)
     private String comment;
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/minsta/m/domain/leels/entity/LeelsCommentEmbedded.java
+++ b/src/main/java/com/minsta/m/domain/leels/entity/LeelsCommentEmbedded.java
@@ -3,41 +3,27 @@ package com.minsta.m.domain.leels.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 @Getter
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class LeelsCommentEmbedded implements Serializable {
 
     @Column(name = "user_id")
     private Long userId;
 
+
     @Column(name = "leels_id")
     private Long leelsId;
 
+
     @Column(name = "leels_comment_id")
     private Long leelsCommentId;
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-
-        LeelsCommentEmbedded that = (LeelsCommentEmbedded) obj;
-
-        if (!Objects.equals(userId, that.userId)) return false;
-        if (!Objects.equals(leelsId, that.leelsId)) return false;
-        return Objects.equals(leelsCommentId, that.leelsCommentId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(userId, leelsId, leelsCommentId);
-    }
 }

--- a/src/main/java/com/minsta/m/domain/leels/entity/LeelsCommentLike.java
+++ b/src/main/java/com/minsta/m/domain/leels/entity/LeelsCommentLike.java
@@ -18,14 +18,17 @@ public class LeelsCommentLike {
     private LeelsCommentEmbedded leelsCommentEmbedded;
 
     @ManyToOne
-    @MapsId("user_id")
+    @MapsId("userId")
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne
-    @MapsId("leels_id")
+    @MapsId("leelsId")
+    @JoinColumn(name = "leels_id")
     private Leels leels;
 
     @ManyToOne
-    @MapsId("leels_comment_id")
+    @MapsId("leelsCommentId")
+    @JoinColumn(name = "leels_comment_id")
     private LeelsComment leelsComment;
 }

--- a/src/main/java/com/minsta/m/domain/leels/exception/CommentDeletePermissionDeniedException.java
+++ b/src/main/java/com/minsta/m/domain/leels/exception/CommentDeletePermissionDeniedException.java
@@ -1,0 +1,11 @@
+package com.minsta.m.domain.leels.exception;
+
+import com.minsta.m.global.error.BasicException;
+import com.minsta.m.global.error.ErrorCode;
+
+public class CommentDeletePermissionDeniedException extends BasicException {
+
+    public CommentDeletePermissionDeniedException() {
+        super(ErrorCode.DELETE_PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/leels/exception/CommentUpdatePermissionDeniedException.java
+++ b/src/main/java/com/minsta/m/domain/leels/exception/CommentUpdatePermissionDeniedException.java
@@ -1,0 +1,11 @@
+package com.minsta.m.domain.leels.exception;
+
+import com.minsta.m.global.error.BasicException;
+import com.minsta.m.global.error.ErrorCode;
+
+public class CommentUpdatePermissionDeniedException extends BasicException {
+
+    public CommentUpdatePermissionDeniedException() {
+        super(ErrorCode.UPDATE_PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/leels/repository/LeelsCommentLikeRepository.java
+++ b/src/main/java/com/minsta/m/domain/leels/repository/LeelsCommentLikeRepository.java
@@ -1,8 +1,11 @@
 package com.minsta.m.domain.leels.repository;
 
+import com.minsta.m.domain.leels.entity.LeelsComment;
 import com.minsta.m.domain.leels.entity.LeelsCommentEmbedded;
 import com.minsta.m.domain.leels.entity.LeelsCommentLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LeelsCommentLikeRepository extends JpaRepository<LeelsCommentLike, LeelsCommentEmbedded> {
+
+    void deleteAllByLeelsComment(LeelsComment leelsComment);
 }

--- a/src/main/java/com/minsta/m/domain/leels/repository/LeelsCommentRepository.java
+++ b/src/main/java/com/minsta/m/domain/leels/repository/LeelsCommentRepository.java
@@ -1,7 +1,10 @@
 package com.minsta.m.domain.leels.repository;
 
+import com.minsta.m.domain.leels.entity.Leels;
 import com.minsta.m.domain.leels.entity.LeelsComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LeelsCommentRepository extends JpaRepository<LeelsComment, Long> {
+
+    LeelsComment findByLeelsCommentIdAndLeels(Long leelsCommentId, Leels leels);
 }

--- a/src/main/java/com/minsta/m/domain/leels/service/LeelsCommentDeleteService.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/LeelsCommentDeleteService.java
@@ -1,0 +1,6 @@
+package com.minsta.m.domain.leels.service;
+
+public interface LeelsCommentDeleteService {
+
+    void execute(Long leelsId, Long leelsCommentId);
+}

--- a/src/main/java/com/minsta/m/domain/leels/service/LeelsCommentLikeCancelService.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/LeelsCommentLikeCancelService.java
@@ -1,0 +1,6 @@
+package com.minsta.m.domain.leels.service;
+
+public interface LeelsCommentLikeCancelService  {
+
+    void execute(Long leelsId, Long leelsCommentId);
+}

--- a/src/main/java/com/minsta/m/domain/leels/service/UpdateLeelsCommentService.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/UpdateLeelsCommentService.java
@@ -1,0 +1,8 @@
+package com.minsta.m.domain.leels.service;
+
+import com.minsta.m.domain.leels.controller.data.request.CreateLeelsCommentRequest;
+
+public interface UpdateLeelsCommentService {
+
+    void execute(Long leelsId, Long leelsCommentId, CreateLeelsCommentRequest updateCommentRequest);
+}

--- a/src/main/java/com/minsta/m/domain/leels/service/impl/LeelsCommentDeleteServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/impl/LeelsCommentDeleteServiceImpl.java
@@ -1,0 +1,40 @@
+package com.minsta.m.domain.leels.service.impl;
+
+import com.minsta.m.domain.leels.entity.LeelsComment;
+import com.minsta.m.domain.leels.exception.CommentDeletePermissionDeniedException;
+import com.minsta.m.domain.leels.repository.LeelsCommentLikeRepository;
+import com.minsta.m.domain.leels.repository.LeelsCommentRepository;
+import com.minsta.m.domain.leels.service.LeelsCommentDeleteService;
+import com.minsta.m.domain.user.entity.User;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.util.LeelsCommentUtil;
+import com.minsta.m.global.util.LeelsUtil;
+import com.minsta.m.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@ServiceWithTransactional
+public class LeelsCommentDeleteServiceImpl implements LeelsCommentDeleteService {
+
+    private final UserUtil userUtil;
+    private final LeelsUtil leelsUtil;
+    private final LeelsCommentUtil leelsCommentUtil;
+    private final LeelsCommentRepository leelsCommentRepository;
+    private final LeelsCommentLikeRepository leelsCommentLikeRepository;
+
+    @Override
+    public void execute(Long leelsId, Long leelsCommentId) {
+        User user = userUtil.getUser();
+
+        LeelsComment leelsComment = leelsCommentRepository.findByLeelsCommentIdAndLeels(leelsCommentId, leelsUtil.getLeels(leelsId));
+        if (!leelsComment.getUser().equals(user)) {
+            throw new CommentDeletePermissionDeniedException();
+        }
+
+        leelsCommentRepository.delete(leelsComment);
+    }
+
+    private void deleteAllLike(Long leelsCommentId) {
+        leelsCommentLikeRepository.deleteAllByLeelsComment(leelsCommentUtil.getComment(leelsCommentId));
+    }
+}

--- a/src/main/java/com/minsta/m/domain/leels/service/impl/LeelsCommentDeleteServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/impl/LeelsCommentDeleteServiceImpl.java
@@ -11,7 +11,9 @@ import com.minsta.m.global.util.LeelsCommentUtil;
 import com.minsta.m.global.util.LeelsUtil;
 import com.minsta.m.global.util.UserUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @ServiceWithTransactional
 public class LeelsCommentDeleteServiceImpl implements LeelsCommentDeleteService {
@@ -31,6 +33,9 @@ public class LeelsCommentDeleteServiceImpl implements LeelsCommentDeleteService 
             throw new CommentDeletePermissionDeniedException();
         }
 
+        log.info("leelsComment {}", leelsComment.getUser().getName());
+
+        deleteAllLike(leelsCommentId);
         leelsCommentRepository.delete(leelsComment);
     }
 

--- a/src/main/java/com/minsta/m/domain/leels/service/impl/LeelsCommentLikeCancelServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/impl/LeelsCommentLikeCancelServiceImpl.java
@@ -1,0 +1,40 @@
+package com.minsta.m.domain.leels.service.impl;
+
+import com.minsta.m.domain.leels.entity.LeelsCommentLike;
+import com.minsta.m.domain.leels.repository.LeelsCommentLikeRepository;
+import com.minsta.m.domain.leels.service.LeelsCommentLikeCancelService;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.util.LeelsCommentUtil;
+import com.minsta.m.global.util.LeelsUtil;
+import com.minsta.m.global.util.UserUtil;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+
+import static com.minsta.m.domain.leels.entity.QLeelsCommentLike.leelsCommentLike;
+
+@Slf4j
+@RequiredArgsConstructor
+@ServiceWithTransactional
+public class LeelsCommentLikeCancelServiceImpl implements LeelsCommentLikeCancelService {
+
+    private final UserUtil userUtil;
+    private final LeelsUtil leelsUtil;
+    private final LeelsCommentUtil leelsCommentUtil;
+    private final LeelsCommentLikeRepository leelsCommentLikeRepository;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public void execute(Long leelsId, Long leelsCommentId) {
+        LeelsCommentLike like = jpaQueryFactory
+                .selectFrom(leelsCommentLike)
+                .where(leelsCommentLike.user.eq(userUtil.getUser()))
+                .where(leelsCommentLike.leels.eq(leelsUtil.getLeels(leelsId)))
+                .where(leelsCommentLike.leelsComment.eq(leelsCommentUtil.getComment(leelsCommentId)))
+                .fetchOne();
+
+        leelsCommentLikeRepository.delete(Objects.requireNonNull(like));
+    }
+}

--- a/src/main/java/com/minsta/m/domain/leels/service/impl/UpdateLeelsCommentDeleteServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/leels/service/impl/UpdateLeelsCommentDeleteServiceImpl.java
@@ -1,0 +1,31 @@
+package com.minsta.m.domain.leels.service.impl;
+
+import com.minsta.m.domain.leels.controller.data.request.CreateLeelsCommentRequest;
+import com.minsta.m.domain.leels.entity.LeelsComment;
+import com.minsta.m.domain.leels.exception.CommentUpdatePermissionDeniedException;
+import com.minsta.m.domain.leels.repository.LeelsCommentRepository;
+import com.minsta.m.domain.leels.service.UpdateLeelsCommentService;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.util.LeelsUtil;
+import com.minsta.m.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@ServiceWithTransactional
+public class UpdateLeelsCommentDeleteServiceImpl implements UpdateLeelsCommentService {
+
+    private final LeelsUtil leelsUtil;
+    private final UserUtil userUtil;
+    private final LeelsCommentRepository leelsCommentRepository;
+
+    @Override
+    public void execute(Long leelsId, Long leelsCommentId, CreateLeelsCommentRequest updateCommentRequest) {
+        LeelsComment leelsComment = leelsCommentRepository.findByLeelsCommentIdAndLeels(leelsCommentId, leelsUtil.getLeels(leelsId));
+        if (!leelsComment.getUser().equals(userUtil.getUser())) {
+            throw new CommentUpdatePermissionDeniedException();
+        }
+
+        leelsComment.setComment(updateCommentRequest.getComment());
+        leelsCommentRepository.save(leelsComment);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/user/entity/SmsAuthentication.java
+++ b/src/main/java/com/minsta/m/domain/user/entity/SmsAuthentication.java
@@ -21,7 +21,7 @@ public class SmsAuthentication {
     @Column(name = "authentication_key", nullable = false)
     private int key;
 
-    @Column(name = "auth_check", nullable = false)
+    @Column(name = "auth_check", nullable = false, columnDefinition="tinyint(1) default 0")
     private boolean check;
 
     public void setCheck(boolean check) {

--- a/src/main/java/com/minsta/m/global/config/QueryDslConfig.java
+++ b/src/main/java/com/minsta/m/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.minsta.m.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/minsta/m/global/error/ErrorCode.java
+++ b/src/main/java/com/minsta/m/global/error/ErrorCode.java
@@ -31,7 +31,9 @@ public enum ErrorCode {
     LEELS_NOT_FOUND("릴스가 없습니다", 404),
 
     //Leels Comment
-    LEELS_COMMENT_NOT_FOUND("릴스 댓글이 없습니다.", 404);
+    LEELS_COMMENT_NOT_FOUND("릴스 댓글이 없습니다.", 404),
+    DELETE_PERMISSION_DENIED("작성자만 삭제가 가능", 403),
+    UPDATE_PERMISSION_DENIED("작성자만 수정이 가능", 403);
 
 
     private final String message;

--- a/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/user/**").permitAll()
                 .requestMatchers(HttpMethod.PATCH, "/auth").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
-                .requestMatchers(HttpMethod.POST, "/leels/**").authenticated()
+                .requestMatchers("/leels/**").authenticated()
                 .requestMatchers(HttpMethod.POST, "/file").authenticated()
                 .anyRequest().denyAll();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새 기능**
    - `LeelsCommentController`에 댓글 삭제, 업데이트 및 좋아요 취소 기능 추가.
    - 댓글 삭제 및 업데이트 권한 거부에 대한 사용자 정의 예외 클래스 추가.
    - 댓글 삭제, 좋아요 취소 및 댓글 업데이트를 위한 서비스 인터페이스 및 구현체 추가.

- **버그 수정**
    - `LeelsCommentLike`에서 `@MapsId` 및 `@JoinColumn` 주석 업데이트.

- **리팩터링**
    - `LeelsCommentEmbedded`에서 `@EqualsAndHashCode` 주석 추가 및 `equals` 및 `hashCode` 메서드 제거.
    - `SmsAuthentication` 클래스의 `auth_check` 열 정의 수정.

- **문서**
    - `.gitignore` 파일에 IntelliJ IDEA 구성 및 플러그인 설정 포함.
    - QueryDSL 버전 5.0.0 구성을 `build.gradle`에 추가하여 QClass 파일 생성.

- **보안**
    - `/leels/**`에 대한 인증 요청에 대한 보안 구성 수정.

- **코드 스타일**
    - `LeelsComment` 클래스에 `setComment` 공개 메서드 추가.

- **테스트**
    - `LeelsCommentLikeRepository`에 `deleteAllByLeelsComment` 메서드 추가.
    - `LeelsCommentRepository`에 `findByLeelsCommentIdAndLeels` 메서드 추가.

- **설정**
    - QueryDSL을 위한 `JPAQueryFactory` 빈 생성을 포함한 구성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->