### PR TITLE
other service chat

### DIFF
--- a/src/main/java/com/minsta/m/domain/chat/controller/RoomController.java
+++ b/src/main/java/com/minsta/m/domain/chat/controller/RoomController.java
@@ -1,14 +1,19 @@
 package com.minsta.m.domain.chat.controller;
 
+import com.minsta.m.domain.chat.controller.data.request.ChatUpdateRequest;
+import com.minsta.m.domain.chat.controller.data.response.ChatResponse;
+import com.minsta.m.domain.chat.controller.data.response.ChatRoomResponse;
 import com.minsta.m.domain.chat.controller.data.response.CreateRoomResponse;
-import com.minsta.m.domain.chat.service.CreateRoomService;
+import com.minsta.m.domain.chat.service.*;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/room")
@@ -16,10 +21,45 @@ import org.springframework.web.bind.annotation.RestController;
 public class RoomController {
 
     private final CreateRoomService createRoomService;
+    private final GetMyCurrentChatListService getMyCurrentChatListService;
+    private final GetAllChatHistoryService getAllChatHistoryService;
+    private final ChatUpdateService chatUpdateService;
+    private final DeleteChatService deleteChatService;
 
     @PostMapping("/{otherUserId}")
     public ResponseEntity<CreateRoomResponse> createRoom(@PathVariable Long otherUserId) {
         var response = createRoomService.execute(otherUserId);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChatRoomResponse>> getCurrentMyChatRoomList() {
+        var response = getMyCurrentChatListService.execute();
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/{roomId}")
+    public ResponseEntity<List<ChatResponse>> getRoomChatList(@PathVariable UUID roomId) {
+        var response = getAllChatHistoryService.execute(roomId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PatchMapping("/{roomId}/{chatId}")
+    public ResponseEntity<HttpStatus> updateChat(
+            @PathVariable Long chatId,
+            @PathVariable UUID roomId,
+            @RequestBody @Valid ChatUpdateRequest chatUpdateRequest
+    ) {
+        chatUpdateService.execute(roomId, chatId, chatUpdateRequest);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @DeleteMapping("/{roomId}/{chatId}")
+    public ResponseEntity<HttpStatus> deleteChat(
+            @PathVariable Long chatId,
+            @PathVariable UUID roomId
+    ) {
+        deleteChatService.execute(roomId, chatId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/minsta/m/domain/chat/controller/data/request/ChatUpdateRequest.java
+++ b/src/main/java/com/minsta/m/domain/chat/controller/data/request/ChatUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.minsta.m.domain.chat.controller.data.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatUpdateRequest {
+
+    private String content;
+}

--- a/src/main/java/com/minsta/m/domain/chat/controller/data/response/ChatResponse.java
+++ b/src/main/java/com/minsta/m/domain/chat/controller/data/response/ChatResponse.java
@@ -1,0 +1,21 @@
+package com.minsta.m.domain.chat.controller.data.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChatResponse {
+
+    private Long userId;
+
+    private String userProfileUrl;
+
+    private String chat;
+
+    private LocalDateTime chatTime;
+}

--- a/src/main/java/com/minsta/m/domain/chat/controller/data/response/ChatRoomResponse.java
+++ b/src/main/java/com/minsta/m/domain/chat/controller/data/response/ChatRoomResponse.java
@@ -1,0 +1,26 @@
+package com.minsta.m.domain.chat.controller.data.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChatRoomResponse {
+
+    private UUID chatRoomId;
+
+    private Long opponentId;
+
+    private String opponentProfileUrl;
+
+    private String opponentNickName;
+
+    private String lastMessage;
+
+    private ZonedDateTime lastMessageTime;
+}

--- a/src/main/java/com/minsta/m/domain/chat/entity/ChatHistory.java
+++ b/src/main/java/com/minsta/m/domain/chat/entity/ChatHistory.java
@@ -30,4 +30,15 @@ public class ChatHistory extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "room_id")
     private ChatRoom chatRoom;
+
+    @Column(nullable = false)
+    private boolean modify;
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setModify(boolean modify) {
+        this.modify = modify;
+    }
 }

--- a/src/main/java/com/minsta/m/domain/chat/repository/ChatHistoryRepository.java
+++ b/src/main/java/com/minsta/m/domain/chat/repository/ChatHistoryRepository.java
@@ -1,7 +1,12 @@
 package com.minsta.m.domain.chat.repository;
 
 import com.minsta.m.domain.chat.entity.ChatHistory;
+import com.minsta.m.domain.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> {
+
+    List<ChatHistory> findAllByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/com/minsta/m/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/minsta/m/domain/chat/repository/ChatRoomRepository.java
@@ -4,9 +4,12 @@ import com.minsta.m.domain.chat.entity.ChatRoom;
 import com.minsta.m.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID> {
 
     boolean existsByUserAndOtherUserId(User user, Long otherUserId);
+
+    List<ChatRoom> findByUserOrOtherUserId(User user, Long otherUserId);
 }

--- a/src/main/java/com/minsta/m/domain/chat/service/ChatUpdateService.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/ChatUpdateService.java
@@ -1,0 +1,10 @@
+package com.minsta.m.domain.chat.service;
+
+import com.minsta.m.domain.chat.controller.data.request.ChatUpdateRequest;
+
+import java.util.UUID;
+
+public interface ChatUpdateService {
+
+    void execute(UUID roomId, Long chatId, ChatUpdateRequest chatUpdateRequest);
+}

--- a/src/main/java/com/minsta/m/domain/chat/service/DeleteChatService.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/DeleteChatService.java
@@ -1,0 +1,8 @@
+package com.minsta.m.domain.chat.service;
+
+import java.util.UUID;
+
+public interface DeleteChatService {
+
+    void execute(UUID roomId, Long chatId);
+}

--- a/src/main/java/com/minsta/m/domain/chat/service/GetAllChatHistoryService.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/GetAllChatHistoryService.java
@@ -1,0 +1,11 @@
+package com.minsta.m.domain.chat.service;
+
+import com.minsta.m.domain.chat.controller.data.response.ChatResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GetAllChatHistoryService {
+
+    List<ChatResponse> execute(UUID roomId);
+}

--- a/src/main/java/com/minsta/m/domain/chat/service/GetMyCurrentChatListService.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/GetMyCurrentChatListService.java
@@ -1,0 +1,10 @@
+package com.minsta.m.domain.chat.service;
+
+import com.minsta.m.domain.chat.controller.data.response.ChatRoomResponse;
+
+import java.util.List;
+
+public interface GetMyCurrentChatListService {
+
+    List<ChatRoomResponse> execute();
+}

--- a/src/main/java/com/minsta/m/domain/chat/service/impl/ChatSaveServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/impl/ChatSaveServiceImpl.java
@@ -38,6 +38,7 @@ public class ChatSaveServiceImpl implements ChatSaveService {
                 .sender(userRepository.findById(message.getSenderId()).orElseThrow(UserNotFoundException::new))
                 .content(message.getMessage())
                 .chatRoom(chatRoom)
+                .modify(false)
                 .build();
 
         chatHistoryRepository.save(chatHistory);

--- a/src/main/java/com/minsta/m/domain/chat/service/impl/ChatUpdateServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/impl/ChatUpdateServiceImpl.java
@@ -1,0 +1,44 @@
+package com.minsta.m.domain.chat.service.impl;
+
+import com.minsta.m.domain.chat.controller.data.request.ChatUpdateRequest;
+import com.minsta.m.domain.chat.entity.ChatHistory;
+import com.minsta.m.domain.chat.entity.ChatRoom;
+import com.minsta.m.domain.chat.repository.ChatHistoryRepository;
+import com.minsta.m.domain.chat.repository.ChatRoomRepository;
+import com.minsta.m.domain.chat.service.ChatUpdateService;
+import com.minsta.m.domain.user.entity.User;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.error.BasicException;
+import com.minsta.m.global.error.ErrorCode;
+import com.minsta.m.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@ServiceWithTransactional
+public class ChatUpdateServiceImpl implements ChatUpdateService {
+
+    private final UserUtil userUtil;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatHistoryRepository chatHistoryRepository;
+
+    @Override
+    public void execute(UUID roomId, Long chatId, ChatUpdateRequest chatUpdateRequest) {
+
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BasicException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        User currentUser = userUtil.getUser();
+        if (room.getUser() != currentUser && room.getOtherUserId().equals(currentUser.getUserId())) {
+            throw new BasicException(ErrorCode.PERMISSION_DENIED_CHAT_ROOM);
+        }
+
+        ChatHistory chatHistory = chatHistoryRepository.findById(chatId)
+                .orElseThrow(() -> new BasicException(ErrorCode.CHAT_NOT_FOUND));
+
+        chatHistory.setContent(chatUpdateRequest.getContent());
+        chatHistory.setModify(true);
+
+        chatHistoryRepository.save(chatHistory);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/chat/service/impl/DeleteChatServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/impl/DeleteChatServiceImpl.java
@@ -1,0 +1,38 @@
+package com.minsta.m.domain.chat.service.impl;
+
+import com.minsta.m.domain.chat.entity.ChatHistory;
+import com.minsta.m.domain.chat.repository.ChatHistoryRepository;
+import com.minsta.m.domain.chat.service.DeleteChatService;
+import com.minsta.m.domain.user.entity.User;
+import com.minsta.m.global.annotation.ServiceWithTransactional;
+import com.minsta.m.global.error.BasicException;
+import com.minsta.m.global.error.ErrorCode;
+import com.minsta.m.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@ServiceWithTransactional
+public class DeleteChatServiceImpl implements DeleteChatService {
+
+    private final UserUtil userUtil;
+    private final ChatHistoryRepository chatHistoryRepository;
+
+    @Override
+    public void execute(UUID roomId, Long chatId) {
+
+        User currentUser = userUtil.getUser();
+        ChatHistory chatHistory = chatHistoryRepository.findById(chatId)
+                .orElseThrow(() -> new BasicException(ErrorCode.CHAT_NOT_FOUND));
+        if (chatHistory.getChatRoom().getChatRoomId() != roomId) {
+            throw new BasicException(ErrorCode.CHAT_ROOM_NOT_FOUND);
+        }
+
+        if (!chatHistory.getSender().equals(currentUser)) {
+            throw new BasicException(ErrorCode.PERMISSION_DENIED_DELETE_CHAT);
+        }
+
+        chatHistoryRepository.delete(chatHistory);
+    }
+}

--- a/src/main/java/com/minsta/m/domain/chat/service/impl/GetMyCurrentChatListServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/impl/GetMyCurrentChatListServiceImpl.java
@@ -1,0 +1,58 @@
+package com.minsta.m.domain.chat.service.impl;
+
+import com.minsta.m.domain.chat.controller.data.response.ChatRoomResponse;
+import com.minsta.m.domain.chat.entity.ChatRoom;
+import com.minsta.m.domain.chat.repository.ChatRoomRepository;
+import com.minsta.m.domain.chat.service.GetMyCurrentChatListService;
+import com.minsta.m.domain.user.entity.User;
+import com.minsta.m.domain.user.repository.UserRepository;
+import com.minsta.m.global.annotation.ReadOnlyService;
+import com.minsta.m.global.security.exception.UserNotFoundException;
+import com.minsta.m.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@ReadOnlyService
+@RequiredArgsConstructor
+public class GetMyCurrentChatListServiceImpl implements GetMyCurrentChatListService {
+
+    private final UserUtil userUtil;
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    public List<ChatRoomResponse> execute() {
+        User currentUser = userUtil.getUser();
+        List<ChatRoom> chatRooms = chatRoomRepository.findByUserOrOtherUserId(currentUser, currentUser.getUserId());
+
+        return chatRooms.stream()
+                .map(chatRoom -> createChatRoomResponse(chatRoom, currentUser))
+                .collect(Collectors.toList());
+    }
+
+    private ChatRoomResponse createChatRoomResponse(ChatRoom chatRoom, User currentUser) {
+        Long opponentId = Objects.equals(chatRoom.getOtherUserId(), currentUser.getUserId()) ? chatRoom.getUser().getUserId() : chatRoom.getOtherUserId();
+        String opponentNickName = fetchNickName(opponentId);
+        String opponentProfileUrl = fetchProfileUrl(opponentId);
+
+        return ChatRoomResponse.builder()
+                .chatRoomId(chatRoom.getChatRoomId())
+                .opponentId(opponentId)
+                .opponentNickName(opponentNickName)
+                .opponentProfileUrl(opponentProfileUrl)
+                .lastMessage(chatRoom.getLastMessage())
+                .lastMessageTime(chatRoom.getLastMessageTime())
+                .build();
+    }
+
+    private String fetchNickName(Long userId) {
+        return userRepository.findById(userId).orElseThrow(UserNotFoundException::new).getNickName();
+    }
+
+    private String fetchProfileUrl(Long userId) {
+        return userRepository.findById(userId).orElseThrow(UserNotFoundException::new).getProfileUrl();
+    }
+
+}

--- a/src/main/java/com/minsta/m/domain/chat/service/impl/GetRoomChatListServiceImpl.java
+++ b/src/main/java/com/minsta/m/domain/chat/service/impl/GetRoomChatListServiceImpl.java
@@ -1,0 +1,47 @@
+package com.minsta.m.domain.chat.service.impl;
+
+import com.minsta.m.domain.chat.controller.data.response.ChatResponse;
+import com.minsta.m.domain.chat.entity.ChatHistory;
+import com.minsta.m.domain.chat.entity.ChatRoom;
+import com.minsta.m.domain.chat.repository.ChatHistoryRepository;
+import com.minsta.m.domain.chat.repository.ChatRoomRepository;
+import com.minsta.m.domain.chat.service.GetAllChatHistoryService;
+import com.minsta.m.global.annotation.ReadOnlyService;
+import com.minsta.m.global.error.BasicException;
+import com.minsta.m.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@ReadOnlyService
+@RequiredArgsConstructor
+public class GetRoomChatListServiceImpl implements GetAllChatHistoryService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatHistoryRepository chatHistoryRepository;
+
+    @Override
+    public List<ChatResponse> execute(UUID roomId) {
+        List<ChatResponse> chatResponses = new ArrayList<>();
+
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new BasicException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        List<ChatHistory> histories = chatHistoryRepository.findAllByChatRoom(chatRoom);
+        for (ChatHistory history : histories) {
+            LocalDateTime time = history.isModify() ? history.getUpdatedAt() : history.getCreatedAt();
+
+            ChatResponse chatResponse = ChatResponse.builder()
+                    .userId(history.getSender().getUserId())
+                    .userProfileUrl(history.getSender().getProfileUrl())
+                    .chat(history.getContent())
+                    .chatTime(time)
+                    .build();
+
+            chatResponses.add(chatResponse);
+        }
+
+        return chatResponses;
+    }
+}

--- a/src/main/java/com/minsta/m/global/error/ErrorCode.java
+++ b/src/main/java/com/minsta/m/global/error/ErrorCode.java
@@ -44,7 +44,10 @@ public enum ErrorCode {
 
     //CHAT
     EXIST_CHAT_ROOM("이미 채팅방이 존재합니다", 400),
-    CHAT_ROOM_NOT_FOUND("채팅방이 존재하지 않습니다", 404);
+    CHAT_ROOM_NOT_FOUND("채팅방이 존재하지 않습니다", 404),
+    PERMISSION_DENIED_CHAT_ROOM("채팅방에 속하지 않음", 403),
+    PERMISSION_DENIED_DELETE_CHAT("채팅 작성자가 아님", 403),
+    CHAT_NOT_FOUND("채팅이 없음", 404);
 
     private final String message;
     private final int status;

--- a/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/minsta/m/global/security/config/SecurityConfig.java
@@ -51,10 +51,14 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
                 .requestMatchers("/leels/**").authenticated()
                 .requestMatchers(HttpMethod.POST, "/file").authenticated()
-                .requestMatchers("/chat/**").permitAll()
+                .requestMatchers("/chat/**").permitAll() //TODO: Stomp security
                 .requestMatchers("/ws/**").permitAll()
-                .requestMatchers("/sub/**").permitAll()
-                .requestMatchers("/pub/**").permitAll()
+                .requestMatchers("/sub/**").permitAll() //TODO: Stomp security
+                .requestMatchers("/pub/**").permitAll() //TODO: Stomp security
+                .requestMatchers(HttpMethod.POST, "/room/**").authenticated()
+                .requestMatchers(HttpMethod.GET, "/room/**").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/room/**").authenticated()
+                .requestMatchers(HttpMethod.PATCH, "/room/**").authenticated()
                 .anyRequest().denyAll();
 
         http


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
	- 새로운 채팅 기능 관련 클래스 추가.
	- 채팅방 목록, 채팅 기록 조회, 채팅 메시지 업데이트 및 삭제를 위한 새로운 컨트롤러 메서드 추가.
	- 특정 채팅방에 속한 채팅 기록을 반환하는 새로운 메서드 추가.
	- 사용자 또는 다른 사용자 ID를 기반으로 채팅방 엔티티 목록을 검색하는 새로운 메서드 추가.
	- 채팅 메시지 업데이트 및 삭제를 위한 새로운 서비스 인터페이스 추가.
	- 현재 사용자의 채팅방 목록을 검색하는 새로운 서비스 인터페이스 추가.
- **버그 수정**
	- 채팅 기록 객체를 생성할 때 `modify` 필드를 `false`로 설정하는 수정 사항 추가.
- **문서**
	- 채팅 권한 및 삭제와 관련된 새로운 오류 코드 추가.
	- 채팅 업데이트 요청, 채팅 메시지, 채팅방 응답에 대한 새로운 데이터 응답 클래스 정의.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->